### PR TITLE
Fix language switching on website

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -29,11 +29,11 @@ extra:
   alternate:
 
     - name: English
-      link: /en/
+      link: /3dbag-docs/en/
       lang: en
 
     - name: Nederlands
-      link: /nl/
+      link: /3dbag-docs/nl/
       lang: nl
   social:
     - icon: fontawesome/brands/twitter

--- a/config/nl/mkdocs.yml
+++ b/config/nl/mkdocs.yml
@@ -29,11 +29,11 @@ extra:
   alternate:
 
     - name: English
-      link: /en/
+      link: /3dbag-docs/en/
       lang: en
 
     - name: Nederlands
-      link: /nl/
+      link: /3dbag-docs/nl/
       lang: nl
   social:
     - icon: fontawesome/brands/twitter


### PR DESCRIPTION
Language switching on the deployed website currently doesn't work due to the added `/3dbag-docs/`. Is this sufficient to fix it? It would break it for local testing though.